### PR TITLE
[feature/SBOT-22] Swagger2.9.2에서  Swagger3.0 으로 변경

### DIFF
--- a/buildSrc/src/main/kotlin/SererDependencies.kt
+++ b/buildSrc/src/main/kotlin/SererDependencies.kt
@@ -1,7 +1,6 @@
-
 object SpringFox {
 
-    const val swagger2 = "io.springfox:springfox-swagger2:_"
-    const val swaggerUi = "io.springfox:springfox-swagger-ui:_"
+    // swagger 3.0, swaggerUi 3.0 같이 추가 해줌.
+    const val swagger3 = "io.springfox:springfox-boot-starter:_"
 
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -25,8 +25,7 @@ dependencies {
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 
-    implementation(SpringFox.swagger2)
-    implementation(SpringFox.swaggerUi)
+    implementation(SpringFox.swagger3)
 
     testImplementation(kotlin("test"))
 }

--- a/versions.properties
+++ b/versions.properties
@@ -74,34 +74,18 @@ version.google.android.material=1.6.0-alpha02
 
 version.google.dagger=2.40.5
 
-version.io.springfox..springfox-swagger-ui=2.9.2
-##                             # available=2.10.0
-##                             # available=2.10.1
-##                             # available=2.10.2
-##                             # available=2.10.3
-##                             # available=2.10.4
-##                             # available=2.10.5
-##                             # available=3.0.0
-
-version.io.springfox..springfox-swagger2=2.9.2
-##                           # available=2.10.0
-##                           # available=2.10.1
-##                           # available=2.10.2
-##                           # available=2.10.3
-##                           # available=2.10.4
-##                           # available=2.10.5
-##                           # available=3.0.0
+version.io.springfox..springfox-boot-starter=3.0.0
 
 version.jakewharton.timber=5.0.1
 
- version.koin=3.1.5
+version.koin=3.1.5
 ### available=3.2.0-beta-1
 
 version.kotlinx.coroutines=1.6.0
 
 version.kotlinx.serialization=1.3.2
 
- version.ktor=2.0.0-beta-1
+version.ktor=2.0.0-beta-1
 
 version.multiplatform-settings=0.8.1
 


### PR DESCRIPTION
## 작업 프로젝트 링크
- [SBOT-22 | Swagger 3.0 의존성 추가 여부 확인](https://saboten.atlassian.net/browse/SBOT-22)

## 작업한 내용
- [x] Swagger 3.0 호환 여부 확인
- [x] Swagger 2.9.2 -> Swagger 3.0 변경

## 비고
- Swagger 3.0 변경으로 인하여 API 문서 URL이 변경됨.
- 예)`http://localhost:8080/swagger-ui/`