### PR TITLE
[feature/SBOT-30]: Logback 과 Sentry 환경구축 및 테스트 로그 전송 구현

### DIFF
--- a/buildSrc/src/main/kotlin/SererDependencies.kt
+++ b/buildSrc/src/main/kotlin/SererDependencies.kt
@@ -28,12 +28,19 @@ object SpringFramework {
     }
 }
 
+object Sentry {
+    const val sentry = "io.sentry:sentry-spring-boot-starter:_"
+    const val logback = "io.sentry:sentry-logback:_"
+}
+
 // serverDependency로 하나로 쓸까, 아니면 기능별로 분리해서 관리할까 고민중
 fun DependencyHandler.serverDependency() {
     add("implementation", SpringFramework.Boot.jpa)
     add("implementation", Postgresql.postgre)
     add("implementation", Lombok.lombok)
     add("implementation", SpringFox.swagger3)
+    add("implementation", Sentry.sentry)
+    add("implementation", Sentry.logback)
 
     add("testImplementation", SpringFramework.Boot.bootTest)
     add("testImplementation", Mockk.mockk)

--- a/server/src/main/resources/application-dev.properties
+++ b/server/src/main/resources/application-dev.properties
@@ -1,4 +1,9 @@
 spring.datasource.driverClassName=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://0.0.0.0:5432/DatabaseName
+spring.datasource.url=jdbc:postgresql://34.64.196.228:5432/test
 spring.datasource.username=postgres
 spring.datasource.password=
+
+sentry.dsn=
+# Set traces-sample-rate to 1.0 to capture 100% of transactions for performance monitoring.
+# We recommend adjusting this value in production.
+sentry.traces-sample-rate=1.0

--- a/server/src/main/resources/application-prod.properties
+++ b/server/src/main/resources/application-prod.properties
@@ -1,4 +1,7 @@
 spring.datasource.driverClassName=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://0.0.0.0:5432/DatabaseName
-spring.datasource.username=
+spring.datasource.url=jdbc:postgresql://34.64.196.228:5432/test
+spring.datasource.username=postgres
 spring.datasource.password=
+
+sentry.dsn=
+sentry.traces-sample-rate=1.0

--- a/server/src/test/java/backend/log/SentryTest.java
+++ b/server/src/test/java/backend/log/SentryTest.java
@@ -1,0 +1,49 @@
+package backend.log;
+
+import io.sentry.Sentry;
+import io.sentry.SentryEvent;
+import io.sentry.SentryLevel;
+import io.sentry.protocol.Message;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+public class SentryTest {
+
+    public void sentMessageException() {
+        try {
+            throw new Exception("Exception 테스트 로그입니다.");
+        } catch (Exception e) {
+            Sentry.captureException(e);
+        }
+    }
+
+    public void sentMessage() {
+        Sentry.captureMessage("Message 테스트 로그입니다.");
+    }
+
+    public void sentEvent() {
+        Message message = new Message();
+        message.setMessage("event Message 테스트 로그입니다.");
+
+        SentryEvent event = new SentryEvent();
+        event.setTag("test_id", UUID.randomUUID().toString());
+        event.setLevel(SentryLevel.ERROR);
+        event.setMessage(message);
+
+        Sentry.captureEvent(event);
+    }
+
+    @Test
+    public void Exception로그 () { sentMessageException();}
+
+    @Test
+    public void 메세지로그() { sentMessage(); }
+
+    @Test
+    public void 이벤트로그() { sentEvent(); }
+}

--- a/versions.properties
+++ b/versions.properties
@@ -103,6 +103,14 @@ version.io.github.raamcosta.compose-destinations..core=1.3.3-beta
 
 version.io.github.raamcosta.compose-destinations..ksp=1.3.3-beta
 
+version.io.sentry..sentry-logback=5.6.2
+##                    # available=6.0.0-alpha.1
+##                    # available=6.0.0-alpha.2
+
+version.io.sentry..sentry-spring-boot-starter=5.6.2
+##                                # available=6.0.0-alpha.1
+##                                # available=6.0.0-alpha.2
+
 version.io.springfox..springfox-boot-starter=3.0.0
 
 version.jakewharton.timber=5.0.1


### PR DESCRIPTION
## 작업 프로젝트 링크
- [SBOT-30 | [Backend] 로깅 Framework 결정 및 의존성 추가](https://saboten.atlassian.net/browse/SBOT-30)

## 작업한 내용
- [x] Sentry 와 Logback 의존성 추가
- [x] Sentry 에 타입별 테스트 로그 전송하는 테스트코드 작성
- [x] Sentry Team 생성  

## 비고
- Slack 연동을 하려면 Slack 초대할수있는 권한이 필요하여 
  나중에 @HarryTylenol 가 Sentry 초대받으면 연동버튼 눌러주는 것이 필요합니다.

<img width="1476" alt="image" src="https://user-images.githubusercontent.com/23453850/157682715-591c77fb-6674-4a97-bd32-5ad6fc329c7a.png">
<img width="991" alt="image" src="https://user-images.githubusercontent.com/23453850/157682758-c851fe72-7958-496a-928b-f6b93e63f9cd.png">
<img width="1479" alt="image" src="https://user-images.githubusercontent.com/23453850/157682836-6ad88883-6bee-49a0-963b-47a64db485b3.png">
