### PR TITLE
[feature/SBOT-132] 댓글 삭제 API 구현

### DIFF
--- a/common-client/src/commonMain/kotlin/commonClient/domain/mapper/PostMapper.kt
+++ b/common-client/src/commonMain/kotlin/commonClient/domain/mapper/PostMapper.kt
@@ -2,7 +2,7 @@ package commonClient.domain.mapper
 
 import common.model.VoteColorsResponse
 import common.model.reseponse.category.CategoryResponse
-import common.model.reseponse.post.CommentResponse
+import common.model.reseponse.comment.CommentResponse
 import common.model.reseponse.post.PostResponse
 import common.model.reseponse.post.VoteResponse
 import commonClient.domain.entity.post.*

--- a/common/src/commonMain/kotlin/common/message/CommentResponseMessage.kt
+++ b/common/src/commonMain/kotlin/common/message/CommentResponseMessage.kt
@@ -1,0 +1,13 @@
+package common.message
+
+enum class CommentResponseMessage(
+    override val message: String,
+    override val statusCode: Int
+) : ResponseMessage {
+    COMMENT_CREATED("댓글이 생성되었습니다.", 201),
+    COMMENT_UPDATED("댓글이 수정되었습니다.", 200),
+    COMMENT_DELETED("댓글이 삭제되었습니다.", 200),
+    COMMENT_FIND_USER("해당 유저가 쓴 댓글들이 조회되었습니다.",200),
+    COMMENT_FIND_ALL("댓글들이 조회되었습니다.", 200),
+    COMMENT_NOT_FOUND("댓글이 존재하지 않습니다.", 404),
+}

--- a/common/src/commonMain/kotlin/common/model/request/comment/CommentCreateRequest.kt
+++ b/common/src/commonMain/kotlin/common/model/request/comment/CommentCreateRequest.kt
@@ -1,4 +1,4 @@
-package common.model.request.post
+package common.model.request.comment
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/common/src/commonMain/kotlin/common/model/reseponse/comment/CommentResponse.kt
+++ b/common/src/commonMain/kotlin/common/model/reseponse/comment/CommentResponse.kt
@@ -1,4 +1,4 @@
-package common.model.reseponse.post
+package common.model.reseponse.comment
 
 import common.model.reseponse.user.UserResponse
 import kotlinx.serialization.SerialName
@@ -9,6 +9,6 @@ data class CommentResponse(
     @SerialName("id") val id: Long,
     @SerialName("text") val text: String,
     @SerialName("author") val author: UserResponse,
-    @SerialName("selected_vote") val selectedVote: Long?,
+    @SerialName("selected_vote") val selectedVote: Int?,
     @SerialName("created_at") val createdAt: String,
 )

--- a/common/src/commonMain/kotlin/common/model/reseponse/user/UserResponse.kt
+++ b/common/src/commonMain/kotlin/common/model/reseponse/user/UserResponse.kt
@@ -7,5 +7,5 @@ import kotlinx.serialization.Serializable
 data class UserResponse(
     @SerialName("id") val id : Long,
     @SerialName("nickname") val nickname : String,
-    @SerialName("profile_photo_url") val profilePhotoUrl : String,
+    @SerialName("profile_photo_url") val profilePhotoUrl : String?,
 )

--- a/server/src/main/java/backend/config/SecurityConfig.java
+++ b/server/src/main/java/backend/config/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                 .antMatchers("/**/auth/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
-                .antMatchers(HttpMethod.GET,  "/**/post", "/**/post/{id}").permitAll()
+                .antMatchers(HttpMethod.GET,  "/**/post", "/**/post/{id}", "/**/post/**").permitAll()
                 .anyRequest().authenticated()   // 나머지 API 는 전부 인증 필요
 
                 // JwtFilter 를 addFilterBefore 로 등록했던 JwtSecurityConfig 클래스를 적용

--- a/server/src/main/java/backend/controller/CommentController.java
+++ b/server/src/main/java/backend/controller/CommentController.java
@@ -79,4 +79,13 @@ public class CommentController {
         return ApiResponse.withMessage(commentResponses,CommentResponseMessage.COMMENT_FIND_USER);
     }
 
+    @ApiOperation(value = "댓글 삭제 API", notes = "본인 댓글을 삭제 합니다.")
+    @DeleteMapping("post/{postId}/comment/{commentId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<Page<CommentResponse>> deleteComment(@PathVariable Long postId, @PathVariable Long commentId){
+        UserEntity userEntity = getUser();
+        commentService.deleteComment(commentId, postId, userEntity);
+        return ApiResponse.withMessage(null,CommentResponseMessage.COMMENT_DELETED);
+    }
+
 }

--- a/server/src/main/java/backend/controller/CommentController.java
+++ b/server/src/main/java/backend/controller/CommentController.java
@@ -1,0 +1,57 @@
+package backend.controller;
+
+import backend.controller.annotation.Version1RestController;
+import backend.jwt.SecurityUtil;
+import backend.model.comment.CommentEntity;
+import backend.model.post.PostEntity;
+import backend.model.user.UserEntity;
+import backend.service.UserService;
+import backend.service.comment.CommentService;
+import backend.service.post.PostService;
+import backend.service.user.VoteSelectService;
+import common.message.CommentResponseMessage;
+import common.model.request.comment.CommentCreateRequest;
+import common.model.reseponse.ApiResponse;
+import common.model.reseponse.comment.CommentResponse;
+import common.model.reseponse.user.UserResponse;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Version1RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final UserService userService;
+    private final PostService postService;
+    private final CommentService commentService;
+    private final VoteSelectService voteSelectService;
+
+    // 로그인 안된 사용자면 null 반환
+    private UserEntity getUser() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        if(userId != null)
+            return userService.findUserEntity(userId);
+
+        return null;
+    }
+
+    @ApiOperation(value = "댓글작성 API", notes = "특정 포스트에 댓글을 작성하는 API입니다.")
+    @PostMapping("post/{postId}/comment")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<CommentResponse> createComment(@PathVariable Long postId, @RequestBody CommentCreateRequest commentCreateRequest){
+        UserEntity userEntity = getUser();
+        PostEntity postEntity = postService.findPost(postId);
+        UserResponse userResponse = new UserResponse(userEntity.getUserId(), userEntity.getNickname(), userEntity.getUserImage());
+        Integer voteSelectEntity = voteSelectService.findVoteSelectResult(userEntity,postEntity);
+        String text = commentCreateRequest.getText();
+        CommentEntity comment = commentService.create(userEntity, postEntity,text);
+        CommentResponse commentResponse = new CommentResponse(comment.getCommentId(), comment.getCommentText(),
+                userResponse, voteSelectEntity, comment.getCommentRegistDate().toString());
+        return ApiResponse.withMessage(commentResponse, CommentResponseMessage.COMMENT_CREATED);
+    }
+}

--- a/server/src/main/java/backend/model/comment/CommentEntity.java
+++ b/server/src/main/java/backend/model/comment/CommentEntity.java
@@ -1,5 +1,6 @@
-package backend.model.post;
+package backend.model.comment;
 
+import backend.model.post.PostEntity;
 import backend.model.user.UserEntity;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;

--- a/server/src/main/java/backend/model/comment/CommentEntity.java
+++ b/server/src/main/java/backend/model/comment/CommentEntity.java
@@ -2,6 +2,7 @@ package backend.model.comment;
 
 import backend.model.post.PostEntity;
 import backend.model.user.UserEntity;
+import common.model.reseponse.comment.CommentResponse;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
@@ -42,5 +43,9 @@ public class CommentEntity {
     @Builder.Default
     @Column(name = "comment_regist_date", nullable = false)
     private LocalDateTime commentRegistDate = LocalDateTime.now();
+
+    public CommentResponse toDto(){
+       return new CommentResponse(this.getCommentId(), this.getCommentText(), this.getUser().toDto(),null, this.getCommentRegistDate().toString());
+    }
 
 }

--- a/server/src/main/java/backend/repository/comment/CommentRepository.java
+++ b/server/src/main/java/backend/repository/comment/CommentRepository.java
@@ -15,4 +15,5 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
     CommentEntity findByPostAndUser(PostEntity post, UserEntity user);
     Page<CommentEntity> findAllByPost(PostEntity post, Pageable pageable);
     Page<CommentEntity> findAllByUser(UserEntity user, Pageable pageable);
+    void deleteByCommentIdAndUser(Long commentId, UserEntity user);
 }

--- a/server/src/main/java/backend/repository/comment/CommentRepository.java
+++ b/server/src/main/java/backend/repository/comment/CommentRepository.java
@@ -1,6 +1,6 @@
-package backend.repository.post;
+package backend.repository.comment;
 
-import backend.model.post.CommentEntity;
+import backend.model.comment.CommentEntity;
 import backend.model.post.PostEntity;
 import backend.model.user.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/server/src/main/java/backend/repository/comment/CommentRepository.java
+++ b/server/src/main/java/backend/repository/comment/CommentRepository.java
@@ -3,6 +3,8 @@ package backend.repository.comment;
 import backend.model.comment.CommentEntity;
 import backend.model.post.PostEntity;
 import backend.model.user.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,4 +13,6 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
     List<CommentEntity> findAllByPost(PostEntity post);
     List<CommentEntity> findAllByUser(UserEntity user);
     CommentEntity findByPostAndUser(PostEntity post, UserEntity user);
+    Page<CommentEntity> findAllByPost(PostEntity post, Pageable pageable);
+    Page<CommentEntity> findAllByUser(UserEntity user, Pageable pageable);
 }

--- a/server/src/main/java/backend/service/comment/CommentService.java
+++ b/server/src/main/java/backend/service/comment/CommentService.java
@@ -1,9 +1,11 @@
 package backend.service.comment;
 
+import backend.exception.ApiException;
 import backend.model.comment.CommentEntity;
 import backend.model.post.PostEntity;
 import backend.model.user.UserEntity;
 import backend.repository.comment.CommentRepository;
+import common.message.CommentResponseMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -39,4 +42,25 @@ public class CommentService {
     public Page<CommentEntity> getAllCommentsByUser(UserEntity userEntity, Pageable pageable) {
         return commentRepository.findAllByUser(userEntity, pageable);
     }
+
+    @Transactional
+    public void deleteComment(Long commentId, Long postId ,UserEntity userEntity) {
+        Optional<CommentEntity> commentCheck = commentRepository.findById(commentId);
+
+        if(commentCheck.isEmpty()) {
+            throw new ApiException(CommentResponseMessage.COMMENT_NOT_FOUND);
+        }
+        else {
+           CommentEntity commentEntity = commentCheck.get();
+           if(commentEntity.getPost().getPostId() != postId) {
+               throw new ApiException(CommentResponseMessage.COMMENT_NOT_FOUND);
+           }
+           if(commentEntity.getUser().getUserId() != userEntity.getUserId()) {
+               throw new ApiException(CommentResponseMessage.COMMENT_NOT_FOUND);
+           }
+        }
+
+        commentRepository.deleteByCommentIdAndUser(commentId, userEntity);
+    }
+
 }

--- a/server/src/main/java/backend/service/comment/CommentService.java
+++ b/server/src/main/java/backend/service/comment/CommentService.java
@@ -1,0 +1,30 @@
+package backend.service.comment;
+
+import backend.model.comment.CommentEntity;
+import backend.model.post.PostEntity;
+import backend.model.user.UserEntity;
+import backend.repository.comment.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public CommentEntity create(UserEntity userEntity, PostEntity postEntity, String text) {
+        CommentEntity commentEntity = CommentEntity.builder()
+                .post(postEntity)
+                .user(userEntity)
+                .commentText(text)
+                .commentLikeCount(0L)
+                .commentRegistDate(LocalDateTime.now())
+                .build();
+        commentEntity = commentRepository.save(commentEntity);
+        return commentEntity;
+    }
+}

--- a/server/src/main/java/backend/service/comment/CommentService.java
+++ b/server/src/main/java/backend/service/comment/CommentService.java
@@ -5,6 +5,8 @@ import backend.model.post.PostEntity;
 import backend.model.user.UserEntity;
 import backend.repository.comment.CommentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,5 +28,15 @@ public class CommentService {
                 .build();
         commentEntity = commentRepository.save(commentEntity);
         return commentEntity;
+    }
+
+    @Transactional
+    public Page<CommentEntity> getAllCommentsByPost(PostEntity postEntity, Pageable pageable) {
+        return commentRepository.findAllByPost(postEntity, pageable);
+    }
+
+    @Transactional
+    public Page<CommentEntity> getAllCommentsByUser(UserEntity userEntity, Pageable pageable) {
+        return commentRepository.findAllByUser(userEntity, pageable);
     }
 }

--- a/server/src/test/java/backend/common/BaseTimeEntityTest.java
+++ b/server/src/test/java/backend/common/BaseTimeEntityTest.java
@@ -1,19 +1,12 @@
 package backend.common;
 
-import backend.model.post.PostEntity;
-import backend.model.user.UserEntity;
-import backend.repository.post.CommentRepository;
+import backend.repository.comment.CommentRepository;
 import backend.repository.post.PostRepository;
 import backend.repository.user.UserRepository;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.transaction.Transactional;
-
-import java.time.LocalDateTime;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional

--- a/server/src/test/java/backend/common/EntityFactory.java
+++ b/server/src/test/java/backend/common/EntityFactory.java
@@ -2,7 +2,7 @@ package backend.common;
 
 import backend.model.category.CategoryEntity;
 import backend.model.post.CategoryInPostEntity;
-import backend.model.post.CommentEntity;
+import backend.model.comment.CommentEntity;
 import backend.model.post.PostEntity;
 import backend.model.post.VoteEntity;
 import backend.model.post.PostLikeEntity;

--- a/server/src/test/java/backend/repository/post/CommentResponseRepositoryTest.java
+++ b/server/src/test/java/backend/repository/post/CommentResponseRepositoryTest.java
@@ -1,9 +1,10 @@
 package backend.repository.post;
 
 import backend.common.EntityFactory;
-import backend.model.post.CommentEntity;
+import backend.model.comment.CommentEntity;
 import backend.model.post.PostEntity;
 import backend.model.user.UserEntity;
+import backend.repository.comment.CommentRepository;
 import backend.repository.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,10 +12,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 


### PR DESCRIPTION
## 작업 프로젝트 링크
- [SBOT-132 | [Backend] 댓글 삭제 API 구현](https://saboten.atlassian.net/browse/SBOT-132)

## 작업한 내용
- [x] 댓글 삭제 API 구현
- [x] 기존 댓글 조회 API가 사용자 인증이 요구 되길래 사용자 인증을 안해도 조회가 되도록 변경 

## 비고
- 
