### PR TITLE
프로필 화면 추가 구현

### DIFF
--- a/android/src/main/java/app/saboten/androidApp/ui/screens/main/profile/ProfileScreen.kt
+++ b/android/src/main/java/app/saboten/androidApp/ui/screens/main/profile/ProfileScreen.kt
@@ -203,7 +203,8 @@ private fun ProfileBannerUi() {
                 Icon(
                     modifier = Modifier.size(20.dp),
                     imageVector = SabotenIcons.Google,
-                    contentDescription = "구글 로고"
+                    contentDescription = "구글 로고",
+                    tint = Color.Unspecified
                 )
                 Spacer(modifier = Modifier.padding(start = 4.dp))
                 Text(


### PR DESCRIPTION
## 작업 프로젝트 링크
- X

## 작업한 내용
- 프로필화면 추가 구현
<img width="376" alt="Screenshot 2023-02-16 at 12 55 49 AM" src="https://user-images.githubusercontent.com/90144041/219080865-7c25fcdb-49f3-424e-b15c-c76b68c2c00f.png">


## 비고
- ~~구글 아이콘이 svg에는 컬러적용이 되어있는데, 가져다쓰면 검은색으로 나오네요.. 컬러 하나가 아니라 어찌해줘야할지...~~
- 게시글, 투표, 스크랩을 나눌 때 figma에는 중간선이 있는데 스킬 부족이슈로 아직 해당 부분은 구현을 못했습니다..
