### PR TITLE
SmallPostCard 카테고리 표시 제대로 되도록 수정

### DIFF
--- a/android/src/main/java/app/saboten/androidApp/ui/screens/main/post/SmallPostCard.kt
+++ b/android/src/main/java/app/saboten/androidApp/ui/screens/main/post/SmallPostCard.kt
@@ -13,12 +13,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Bookmark
@@ -28,8 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -121,9 +116,10 @@ fun SmallPostCard(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Row() {
-                    GroupItem("음식")
-                    Spacer(modifier = Modifier.padding(horizontal = 3.dp))
-                    GroupItem("취향")
+                    post.categories.take(2).forEach {
+                        GroupItem(it.name)
+                        Spacer(modifier = Modifier.padding(horizontal = 3.dp))
+                    }
                 }
 
                 Row() {


### PR DESCRIPTION
## 작업 프로젝트 링크

## 작업한 내용
- 기존에 SmallPostCard에 정적으로 되어있던 타입 표시를 게시글 정보에서 최대 2개 불러와서 표시하도록 변경

## 비고
- 감사합니다
