### PR TITLE
[one-tab-login-fix] 구글 로그인 이슈 관련 로그인 방식 수정

### DIFF
--- a/android/src/main/java/app/saboten/androidApp/ui/dialog/GoogleLoginManager.kt
+++ b/android/src/main/java/app/saboten/androidApp/ui/dialog/GoogleLoginManager.kt
@@ -1,41 +1,21 @@
 package app.saboten.androidApp.ui.dialog
 
 import android.app.Activity
-import android.content.Context
-import android.content.Intent
 import android.content.IntentSender
-import android.util.Log
 import app.saboten.androidApp.R
-import com.google.android.gms.auth.api.identity.BeginSignInRequest
+import com.google.android.gms.auth.api.identity.GetSignInIntentRequest
 import com.google.android.gms.auth.api.identity.Identity
-import com.google.android.gms.auth.api.identity.SignInClient
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import kotlinx.coroutines.tasks.await
-import timber.log.Timber
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
 
 class GoogleLoginManager(private val activity: Activity) {
 
-    var oneTapClient: SignInClient = Identity.getSignInClient(activity)
-
     suspend fun signInIntent() : IntentSender {
-        val signInRequest = BeginSignInRequest.builder()
-            .setPasswordRequestOptions(BeginSignInRequest.PasswordRequestOptions.builder()
-                .setSupported(true)
-                .build())
-            .setGoogleIdTokenRequestOptions(
-                BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
-                    .setSupported(true)
-                    .setServerClientId("844420568567-1jregijk4e5llm921r8mabrf85l1v0cj.apps.googleusercontent.com")
-                    .setFilterByAuthorizedAccounts(false)
-                    .build())
-            .setAutoSelectEnabled(true)
+        val request = GetSignInIntentRequest.builder()
+            .setServerClientId(activity.getString(R.string.default_web_client_id))
             .build()
 
-        return oneTapClient.beginSignIn(signInRequest).await().pendingIntent.intentSender
+        val intent = Identity.getSignInClient(activity).getSignInIntent(request).await()
+        return intent.intentSender
     }
 
 }

--- a/android/src/main/java/app/saboten/androidApp/ui/dialog/LoginDialog.kt
+++ b/android/src/main/java/app/saboten/androidApp/ui/dialog/LoginDialog.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import app.saboten.androidApp.ui.buttons.GoogleLoginButton
 import app.saboten.androidUi.utils.getActivity
+import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.ramcosta.composedestinations.annotation.Destination
@@ -90,7 +91,7 @@ fun LoginDialogContent(
             ClientLogger.d("Success")
             val intent = result.data
             if (intent != null) {
-                val credential = googleLoginManager.oneTapClient.getSignInCredentialFromIntent(intent)
+                val credential = Identity.getSignInClient(context.getActivity()!!).getSignInCredentialFromIntent(intent)
                 val googleIdToken = credential.googleIdToken
                 ClientLogger.d("Success $googleIdToken")
                 if (googleIdToken != null) {


### PR DESCRIPTION
# 구글 로그인 이슈 관련 로그인 방식 수정
구글 로그인 과정에 다른 방법을 사용하였습니다.
가운데에 Dialog 가 뜨는 방식입니다. ([참고](https://developers.google.com/identity/sign-in/android/sign-in-identity))

![image](https://user-images.githubusercontent.com/22587486/232561543-140fd170-a4f5-4fc4-b8f4-5040aec5842a.png)
