### PR TITLE
홈 페이지에서 SmallPostCard 아이템들의 좋아요, 댓글 클릭 이벤트 구현

### DIFF
--- a/android/src/main/java/app/saboten/androidApp/ui/screens/main/home/HomeScreen.kt
+++ b/android/src/main/java/app/saboten/androidApp/ui/screens/main/home/HomeScreen.kt
@@ -208,6 +208,9 @@ fun HomeScreenContent(
                                         onClicked = {
                                             onPostClicked(nonNullPost)
                                         },
+                                        onLikeClicked = {
+                                            vm.requestLike(nonNullPost.id)
+                                        },
                                         onCommentClicked = {
                                             onPostClicked(nonNullPost)
                                         }
@@ -239,10 +242,14 @@ fun HomeScreenContent(
                                 val observableCache by vm.updatedPostCache.collectAsState()
                                 val cachedPost = observableCache.firstOrNull { post.id == it.id } ?: post
                                 cachedPost.let { nonNullPost ->
+
                                     SmallPostCard(
                                         post = nonNullPost,
                                         onClicked = {
                                             onPostClicked(nonNullPost)
+                                        },
+                                        onLikeClicked = {
+                                            vm.requestLike(nonNullPost.id)
                                         },
                                         onCommentClicked = {
                                             onPostClicked(nonNullPost)

--- a/android/src/main/java/app/saboten/androidApp/ui/screens/main/home/HomeScreen.kt
+++ b/android/src/main/java/app/saboten/androidApp/ui/screens/main/home/HomeScreen.kt
@@ -267,10 +267,10 @@ fun HomeScreenContent(
                                 .padding(horizontal = 20.dp, vertical = 10.dp),
                             post = cachedPost,
                             onClicked = {
-
+                                onPostClicked(cachedPost)
                             },
                             onCommentClicked = {
-
+                                onPostClicked(cachedPost)
                             },
                             onVoteClicked = { vote -> vm.requestVote(cachedPost.id, vote.id) },
                             onScrapClicked = { vm.requestScrap(cachedPost.id) },

--- a/android/src/main/java/app/saboten/androidApp/ui/screens/main/home/HomeScreen.kt
+++ b/android/src/main/java/app/saboten/androidApp/ui/screens/main/home/HomeScreen.kt
@@ -207,6 +207,9 @@ fun HomeScreenContent(
                                         post = nonNullPost,
                                         onClicked = {
                                             onPostClicked(nonNullPost)
+                                        },
+                                        onCommentClicked = {
+                                            onPostClicked(nonNullPost)
                                         }
                                     )
                                     Spacer(modifier = Modifier.width(10.dp))
@@ -239,6 +242,9 @@ fun HomeScreenContent(
                                     SmallPostCard(
                                         post = nonNullPost,
                                         onClicked = {
+                                            onPostClicked(nonNullPost)
+                                        },
+                                        onCommentClicked = {
                                             onPostClicked(nonNullPost)
                                         }
                                     )

--- a/android/src/main/java/app/saboten/androidApp/ui/screens/main/home/more/MoreScreen.kt
+++ b/android/src/main/java/app/saboten/androidApp/ui/screens/main/home/more/MoreScreen.kt
@@ -86,10 +86,10 @@ fun MoreScreen(
                         modifier = Modifier.fillMaxWidth(),
                         post = nonNullPost,
                         onClicked = {
-                            navigator.navigate(DetailPostScreenDestination(post.id))
+                            navigator.navigate(DetailPostScreenDestination(nonNullPost.id))
                         },
                         onCommentClicked = {
-
+                            navigator.navigate(DetailPostScreenDestination(nonNullPost.id))
                         },
                         onVoteClicked = { vote -> viewModel.requestVote(nonNullPost.id, vote.id) },
                         onScrapClicked = { viewModel.requestScrap(nonNullPost.id) },


### PR DESCRIPTION
## 작업 프로젝트 링크
- X

## 작업한 내용
- 홈 페이지에서 SmallPostCard 아이템들의 좋아요, 댓글 클릭 이벤트 구현

## 비고
- CommentClick 관련된 애들이 우선은 상세 페이지로 이동하도록 만들었는데, 아주아주아주~~ 먼 미래에 디자인 스팩처럼 바텀시트가 된다면.... 그 때 수정하면 될 것 같아요
